### PR TITLE
Rewrite structure_check

### DIFF
--- a/app/checks/structure_check.py
+++ b/app/checks/structure_check.py
@@ -1,48 +1,94 @@
 import ast
+from enum import Enum
+
+class NodeType(Enum):
+    ROOT = 0
+    CLASS = 1
+    FUNCTION = 2
+
+    def __str__(self) -> str:
+        if self == NodeType.CLASS:
+            return "Class"
+        elif self == NodeType.FUNCTION:
+            return "Function"
+        else:
+            return ""
+
+class Node:
+    def __init__(self, type: NodeType):
+        self.type = type
+        self.children = []
+    
+    def add_child(self, child):
+        self.children.append(child)
+    
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Node):
+            return False
+        else:
+            if self.type != other.type:
+                return False
+            for child1, child2 in zip(self.children, other.children):
+                if child1 != child2:
+                    return False
+            return True
+
+    def __str__(self) -> str:
+        if len(self.children) == 0:
+            return str(self.type)
+        
+        out = f"{self.type} ["
+        for i, child in enumerate(self.children):
+            out += str(child)
+            if i != len(self.children) - 1:
+                out += ", "
+        return f"{out}]"
 
 
-def extract_definitions(node, parent=None):
-    definitions = []
+def extract_definitions(node, parent):
     for child in ast.iter_child_nodes(node):
-
         if isinstance(child, ast.FunctionDef):
-            if parent is None:
-                definitions.append((child.name, "2"))
-            else:
-                definitions.append((child.name, parent))
-            definitions.extend(extract_definitions(child, parent=child.name))
+            child_node = extract_definitions(child, Node(NodeType.FUNCTION))
+            parent.add_child(child_node)
         elif isinstance(child, ast.ClassDef):
-            if parent is None:
-                definitions.append((child.name, "2"))
-            else:
-                definitions.append((child.name, parent))
-            definitions.extend(extract_definitions(child, parent=child.name))
-    return definitions
+            child_node = extract_definitions(child, Node(NodeType.CLASS))
+            parent.add_child(child_node)
+    return parent
 
 
 def split_structure(code_str):
     tree = ast.parse(code_str)
-    hierarchy = extract_definitions(tree)
-    # guarantee the root of the tree is unique
-    hierarchy.append(("2", "1"))
+    hierarchy = extract_definitions(tree, Node(NodeType.ROOT))
     return hierarchy
 
 
 def check_structure(response, answer):
-    return set(split_structure(response)) == set(split_structure(answer))
+    return split_structure(response) == split_structure(answer)
 
 
 if __name__ == '__main__':
     response = """
 def hello():
-    def hi():
-        pass"""
+    def foo():
+        pass
+    def hello():
+        def bar():
+            pass
+    
+"""
 
     answer = """
-def hello():
-    def hil():
-        pass"""
-
+class hello:
+    def foo():
+        pass
+    
+    def bar():
+        pass
+    
+    def hello():
+        pass
+"""
+    print(NodeType.CLASS)
     print(split_structure(response))
     print(split_structure(answer))
     print(check_structure(response, answer))

--- a/app/evaluation_tests.py
+++ b/app/evaluation_tests.py
@@ -21,19 +21,52 @@ class TestEvaluationFunction(unittest.TestCase):
     Use evaluation_function() to check your algorithm works
     as it should.
     """
-
-    def test_general_eval(self):
-        response = """
-a=2
-"""
-        answer = """
-a=3
-"""
-        check_list = "a"
-        is_correct = False
-        result = evaluation_function(response, answer, Params(check_list=check_list))
-        print(result['is_correct'])
-        print(result['feedback'])
+    
+    def test_structure_check(self):
+        from .checks.structure_check import check_structure
+        # Verify that structures with the same parent names are not 
+        # marked as correct (this would have returned true before)
+        self.assertFalse(check_structure("""
+def hello():
+    def foo():
+        pass
+    def hello():
+        def bar():
+            pass
+""", """
+class hello:
+    def foo():
+        pass
+    
+    def bar():
+        pass
+    
+    def hello():
+        pass
+"""))
+        # Code with the same structure but different function/class
+        # names should still be accepted.
+        self.assertTrue(check_structure("""
+class hello:
+    def foo():
+        pass
+    
+    def bar():
+        pass
+    
+    def hello():
+        pass
+""", """
+class lorem:
+    def ipsum():
+        pass
+    
+    def dolor():
+        pass
+    
+    def sit():
+        pass
+"""))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When I was reading though the evaluation code, I noticed that structure_check probably isn't working as you intended it to. Previously, only one level of nesting was checked, and no distinction was made between functions and classes.

For example, these two pieces of code:
```python
class hello:
    def foo():
        pass
    
    def bar():
        pass
    
    def hello():
        pass
```
and 
```python
def hello():
    def foo():
        pass
    def hello():
        def bar():
            pass
```
would be considered the same, even though they are clearly very different.

I have rewritten `structure_check.py` to ensure that the whole class/function heirarchy is equal. Also, I have removed the requirement for the names to be the same, as code can be completely equivalent even though different names are used.

Using my rewritten code, the above example would correctly return false. 

Please take a look at my changes, and let me know if there is anything you want done differently.

P.S. I have added a test in `evaluation_tests.py` to ensure that my changes work correctly. These tests get run automatically when you push a commit to GitHub, so you can ensure that you never push a change that breaks functionality. I would recommend that you write similar tests for all the new features you implement.
